### PR TITLE
Add endpoint for image url

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -1,4 +1,5 @@
 require 'sinatra'
+require "sinatra/json"
 require "sinatra/reloader"
 require_relative 'wallpaper_url_query.rb'
 require_relative 'api_params_bridge.rb'
@@ -9,4 +10,12 @@ get '/' do
   image_url = WallpaperUrlQuery.new(tags).random_image
 
   redirect image_url
+end
+
+get '/url/' do
+  parameters = APIParamsBridge.new(params)
+  tags = parameters.give_tags
+  image_url = WallpaperUrlQuery.new(tags).random_image
+
+  json url: image_url
 end


### PR DESCRIPTION
Adding an API endpoint to only return the URL, for more flexible async usage.